### PR TITLE
Remove deprecated `flux install --arch` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ flux check --pre
 Install the controllers on your cluster:
 
 ```console
-$ flux install --arch=amd64
+$ flux install
 
 ✚ generating manifests
 ✔ manifests build completed


### PR DESCRIPTION
Output: "Flag --arch has been deprecated, multi-arch container image is now available for AMD64, ARMv7 and ARM64"