### PR TITLE
Add Flagger support for Linkerd 2.13

### DIFF
--- a/infrastructure/flagger/kustomization.yaml
+++ b/infrastructure/flagger/kustomization.yaml
@@ -6,5 +6,3 @@ resources:
   - repository.yaml
   - release.yaml
   - loadtester.yaml
-
-

--- a/infrastructure/flagger/release.yaml
+++ b/infrastructure/flagger/release.yaml
@@ -20,3 +20,5 @@ spec:
   values:
     meshProvider: linkerd
     metricsServer: http://prometheus.linkerd-viz:9090
+    linkerdAuthPolicy:
+      create: true


### PR DESCRIPTION
Update Flagger HelmRelease to have `spec.values.linkerdAuthPolicy.create=true`.This enables the creation of the required `AuthorizationPolicy` which lets Flagger and the loadtester service talk to the Prometheus server in the `linkerd-viz` ns.

Fixes #9 